### PR TITLE
Adding robustica clustering plots to the TEDANA report

### DIFF
--- a/tedana/decomposition/ica.py
+++ b/tedana/decomposition/ica.py
@@ -78,13 +78,14 @@ def tedica(
             max_it=maxit,
         )
     elif ica_method == "fastica":
-        mmix, fixed_seed, c_labels, similarity_t_sne = f_ica(
+        mmix, fixed_seed = f_ica(
             data,
             n_components=n_components,
             fixed_seed=fixed_seed,
             maxit=maxit,
             maxrestart=maxrestart,
         )
+        c_labels = similarity_t_sne = None
     else:
         raise ValueError("The selected ICA method is invalid!")
 
@@ -197,7 +198,7 @@ def r_ica(data, n_components, fixed_seed, n_robust_runs, max_it):
 
     c_labels = robust_ica.clustering.labels_
 
-    perplexity = robust_ica.S_all.shape[1]
+    perplexity = min(robust_ica.S_all.shape[1]-1, 80)
 
     if perplexity < 81:
         perplexity = perplexity - 1
@@ -285,4 +286,4 @@ def f_ica(data, n_components, fixed_seed, maxit, maxrestart):
 
     mmix = ica.mixing_
     mmix = stats.zscore(mmix, axis=0)
-    return mmix, fixed_seed, np.zeros((1,)), np.zeros((1,))
+    return mmix, fixed_seed

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -780,7 +780,7 @@ def tedana_workflow(
         n_restarts = 0
         seed = fixed_seed
         while keep_restarting:
-            mmix, seed = decomposition.tedica(
+            mmix, seed, cluster_labels, similarity_t_sne = decomposition.tedica(
                 dd,
                 n_components,
                 seed,
@@ -1026,6 +1026,12 @@ def tedana_workflow(
 
         dn_ts, hikts, lowkts = io.denoise_ts(data_oc, mmix, mask_denoise, comptable)
 
+        if ica_method == "robustica":
+            reporting.static_figures.clustering_results(
+                cluster_labels=cluster_labels,
+                similarity_t_sne=similarity_t_sne,
+                io_generator=io_generator,
+            )
         reporting.static_figures.plot_adaptive_mask(
             optcom=data_oc,
             base_mask=mask,


### PR DESCRIPTION
To visualise the clustering results created by `robustica`, I have added 2D plots using T-distributed Stochastic Neighbor Embedding (TSNE), https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html, in this pull request. In the created 2D plot each black circle represents a clustered run for an ICA component. I used dilated convex hulls to illustrate clusters for each ICA component.  When DBSCAN is used for clustering (the first option in ica.py in `tedana` 24.0.2), there may be runs considered noisy samples and thus are not clustered. These samples are labelled by -1. In a second plot, these unclustered runs are superimposed on the first plot and are distinguished by red crosses. These plots are saved in the _figures_ folder of the subject where other generated figures are saved.  Examples of these plots are presented here. I have not included any numbers on the axes as the numbers do not convey meaningful information. Of note, if there is no cluster labelled -1, only one figure is generated. 


![clustering_projection_tsne](https://github.com/user-attachments/assets/812ac6cf-7b55-4289-8c81-460759336155)
![clustering_projection_tsne_with_noise](https://github.com/user-attachments/assets/bd0c22e6-7396-4249-9918-b51cb7bf5305)


These plots and the Index Quality (IQ) provide an insight into the quality of the `robustica` results. The objective is to add these plots (interactively) to the HTML report. 

@Lestropie, could you please look at this internal PR and send me your feedback? 